### PR TITLE
add support for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.git/
+tests/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9-slim-bullseye
+
+WORKDIR /app
+
+COPY . /app/
+
+RUN \
+  apt update && \
+  apt install -y --no-install-recommends gcc libcairo2-dev libgeos-dev && \
+  pip install --upgrade pip && \
+  pip install . && \
+  mkdir -p /maps/cache
+
+VOLUME ["/maps"]
+ENTRYPOINT ["map-machine"]
+


### PR DESCRIPTION
This pull requests adds support to let map-machine run in a container. The added `Dockerfile` is a first running version, which has room for improvement, e.g. do not run the processes as root and use a virtual env, reduce image size by cleaning up apt cache. The `.dockerignore` ignores copying files to the container, which are not needed.

The docker build and an example call can look like this:

```
docker build -t strubbl_mapmachine .
docker run -v /data/mapmachine/maps:/maps strubbl_mapmachine render --cache /maps/cache -z 18 -o /maps/wentorf.svg -b 10.2445866411,53.4858307519,10.2726961915,53.4981753961
```


What is GEOS library used for? My example render call works without this library being installed. Do you know [which Debian package](https://packages.debian.org/search?keywords=geos&searchon=names&suite=stable&section=all) is needed to be installed, e.g. libgeos-dev?