### PR TITLE
Deprecate the usage of `pip install .`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Requirements: Python 3.9.
   * install Python packages:
 
 ```bash
-pip install .
+pip install -r requirements.txt
 ```
 
 Map generation


### PR DESCRIPTION
According to https://github.com/pypa/pip/issues/7555

```bash
DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
```