### PR TITLE
Deal with edge case of zero length paths.

### DIFF
--- a/map_machine/feature/road.py
+++ b/map_machine/feature/road.py
@@ -568,8 +568,13 @@ class Road(Tagged):
             lane_offset: float = self.scale * (
                 -self.width / 2.0 + index * self.width / len(self.lanes)
             )
+
+            tmp_d=self.line.get_path(self.placement_offset + lane_offset)
+            if tmp_d == None:
+                return
+
             path: Path = Path(
-                d=self.line.get_path(self.placement_offset + lane_offset)
+                d=tmp_d
             )
             style: dict[str, Any] = {
                 "fill": "none",

--- a/map_machine/geometry/vector.py
+++ b/map_machine/geometry/vector.py
@@ -65,6 +65,9 @@ class Polyline:
             except (ValueError, NotImplementedError):
                 points = self.points
 
+        if len(points) < 2: # Deal with malformed paths
+            return None
+
         return (
             "M "
             + " L ".join(f"{point[0]},{point[1]}" for point in points)


### PR DESCRIPTION
When cropping larger OSM datasets sometimes paths with zero nodes are formed.
Such paths break path -> svg code.

Checking for len < 2 resolves this problem.