### PR TITLE
fixing mutable dataclass attribute error by using default_factory

### DIFF
--- a/map_machine/pictogram/icon.py
+++ b/map_machine/pictogram/icon.py
@@ -370,7 +370,7 @@ class ShapeSpecification:
 
     shape: Shape
     color: Color
-    offset: np.ndarray = np.array((0.0, 0.0))
+    offset: np.ndarray = field(default_factory=lambda: np.array((0.0, 0.0)))
     flip_horizontally: bool = False
     flip_vertically: bool = False
     use_outline: bool = True


### PR DESCRIPTION
Fix for https://github.com/enzet/map-machine/issues/153 where due to changes in python 3.11 (https://docs.python.org/3/whatsnew/3.11.html#dataclasses) mutable fields are no longer allowed and need the `default_factory` argument.