### PR TITLE
fix: Makes fields a keyword arg for urllib3 v1 and v2 compatibility.

### DIFF
--- a/map_machine/osm/osm_getter.py
+++ b/map_machine/osm/osm_getter.py
@@ -71,7 +71,7 @@ def get_data(address: str, parameters: dict[str, str]) -> bytes:
     urllib3.disable_warnings()
 
     try:
-        result = pool_manager.request("GET", address, parameters)
+        result = pool_manager.request("GET", address, fields=parameters)
     except urllib3.exceptions.MaxRetryError:
         raise NetworkError("Cannot download data: too many attempts.")
 


### PR DESCRIPTION
This fixes an incompatibility between using urllib3 v1 and v2, due breaking changes to the `request(..)` method's signature:

[urllib3 v1](https://urllib3.readthedocs.io/en/1.26.x/reference/urllib3.request.html#urllib3.request.RequestMethods.request):
```python
request(method, url, fields=None, headers=None, **urlopen_kw)
```

[urllib3 v2](https://urllib3.readthedocs.io/en/2.0.0/reference/urllib3.poolmanager.html#urllib3.PoolManager.request):
```python
request(method, url, body=None, fields=None, headers=None, json=None, **urlopen_kw)
```


Aside: To avoid similar issues due to breaking changes in dependencies, the `requirements.txt` files should probably be updated to have versions with both lower _and_ upper bounds:
`urllib3>=1.25.6` -> `urllib3>=1.25.6,<2.0.0`