### PR TITLE
feat: Adds --update-cache flag to 'server'.

### DIFF
--- a/map_machine/slippy/server.py
+++ b/map_machine/slippy/server.py
@@ -74,6 +74,7 @@ def run_server(options: argparse.Namespace) -> None:
     try:
         handler = TileServerHandler
         handler.cache = Path(options.cache)
+        handler.update_cache = options.update_cache
         handler.options = options
         server = HTTPServer(("", options.port), handler)
         logging.info(f"Server started on port {options.port}.")

--- a/map_machine/ui/cli.py
+++ b/map_machine/ui/cli.py
@@ -271,6 +271,12 @@ def add_server_arguments(parser: argparse.ArgumentParser) -> None:
         metavar="<path>",
     )
     parser.add_argument(
+        "--update-cache",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="allow writing to cache",
+    )
+    parser.add_argument(
         "--port",
         help="port number",
         default=8080,


### PR DESCRIPTION
`TileServerHandler`has an attribute, `update_cache` which is hardcoded to `False`.
https://github.com/enzet/map-machine/blob/main/map_machine/slippy/server.py#L22

This prevents the `map-machine server` command from serving tiles that aren't already in the cache:
https://github.com/enzet/map-machine/blob/main/map_machine/slippy/server.py#L48-L60

This PR exposes `update_cache` as a command line flag.