### PR TITLE
feat: Adds 'map' flags to the 'server' command.

### DIFF
--- a/map_machine/slippy/server.py
+++ b/map_machine/slippy/server.py
@@ -8,6 +8,7 @@ from typing import Optional
 import cairosvg
 
 from map_machine.map_configuration import MapConfiguration
+from map_machine.scheme import Scheme
 from map_machine.slippy.tile import Tile
 from map_machine.workspace import workspace
 
@@ -48,15 +49,22 @@ class TileServerHandler(SimpleHTTPRequestHandler):
         if self.update_cache:
             if not png_path.exists():
                 if not svg_path.exists():
+                    scheme = Scheme.from_file(
+                        workspace.DEFAULT_SCHEME_PATH
+                        if self.options.scheme == "default"
+                        else Path(self.options.scheme)
+                    )
                     tile.draw(
                         tile_path,
                         self.cache,
-                        MapConfiguration(zoom_level=zoom_level),
+                        MapConfiguration.from_options(
+                            scheme,
+                            self.options,
+                            zoom_level,
+                        ),
                     )
                 with svg_path.open(encoding="utf-8") as input_file:
-                    cairosvg.svg2png(
-                        file_obj=input_file, write_to=str(png_path)
-                    )
+                    cairosvg.svg2png(file_obj=input_file, write_to=str(png_path))
                 logging.info(f"SVG file is rasterized to {png_path}.")
 
         if png_path.exists():

--- a/map_machine/ui/cli.py
+++ b/map_machine/ui/cli.py
@@ -77,14 +77,15 @@ def parse_arguments(args: list[str]) -> argparse.Namespace:
     add_tile_arguments(tile_parser)
     add_map_arguments(tile_parser)
 
-    add_server_arguments(
-        subparser.add_parser(
-            "server",
-            description="Run in order to display generated tiles as a map "
-            "(e.g. with Leaflet).",
-            help="run tile server",
-        )
+    server_parser = subparser.add_parser(
+        "server",
+        description="Run in order to display generated tiles as a map "
+        "(e.g. with Leaflet).",
+        help="run tile server",
     )
+    add_server_arguments(server_parser)
+    add_map_arguments(server_parser)
+
     add_draw_arguments(
         subparser.add_parser(
             "draw",


### PR DESCRIPTION
This enables passing `--scheme `, `--hide-credit`, etc. to `map-machine server`, similar to the `map-machine render` and `map-machine tile` commands.