### PR TITLE
Add natural=shrub.

### DIFF
--- a/map_machine/geometry/flinger.py
+++ b/map_machine/geometry/flinger.py
@@ -40,7 +40,7 @@ def osm_zoom_level_to_pixels_per_meter(
         function allows any non-negative float value
     :param equator_length: celestial body equator length in meters
     """
-    return 2.0**zoom_level / equator_length * 256.0
+    return 2.0 ** zoom_level / equator_length * 256.0
 
 
 class Flinger:
@@ -74,7 +74,7 @@ class MercatorFlinger(Flinger):
         :param equator_length: celestial body equator length in meters
         """
         self.geo_boundaries: BoundaryBox = geo_boundaries
-        self.ratio: float = 2.0**zoom_level * 256.0 / 360.0
+        self.ratio: float = 2.0 ** zoom_level * 256.0 / 360.0
         size: np.ndarray = self.ratio * (
             pseudo_mercator(self.geo_boundaries.max_())
             - pseudo_mercator(self.geo_boundaries.min_())

--- a/map_machine/scheme/default.yml
+++ b/map_machine/scheme/default.yml
@@ -1903,6 +1903,8 @@ node_icons:
       set_main_color: evergreen_color
     - tags: {natural: bush}
       shapes: [{shape: bush, color: tree_color}]
+    - tags: {natural: shrub}
+      shapes: [{shape: bush, color: tree_color}]      
 
     - tags: {natural: tree, genus: Betula}
       shapes: [{shape: betula, color: tree_color}]

--- a/map_machine/slippy/tile.py
+++ b/map_machine/slippy/tile.py
@@ -55,7 +55,7 @@ class Tile:
         :param zoom_level: zoom level in OpenStreetMap terminology
         """
         lat_rad: np.ndarray = np.radians(coordinates[0])
-        scale: float = 2.0**zoom_level
+        scale: float = 2.0 ** zoom_level
         x: int = int((coordinates[1] + 180.0) / 360.0 * scale)
         y: int = int((1.0 - np.arcsinh(np.tan(lat_rad)) / np.pi) / 2.0 * scale)
         return cls(x, y, zoom_level)
@@ -66,7 +66,7 @@ class Tile:
 
         Code from https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
         """
-        scale: float = 2.0**self.zoom_level
+        scale: float = 2.0 ** self.zoom_level
         lon_deg: float = self.x / scale * 360.0 - 180.0
         lat_rad: float = np.arctan(np.sinh(np.pi * (1 - 2 * self.y / scale)))
         lat_deg: np.ndarray = np.degrees(lat_rad)


### PR DESCRIPTION
According to [OSM Wiki](https://wiki.openstreetmap.org/wiki/Tag:natural%3Dshrub) its preferred to use `natural=shrub` to map shrubs and bushes. Map Machine didnt have support for `natural=shrub`, so i added it.