### PR TITLE
Catch case, if value to update with is None

### DIFF
--- a/map_machine/util.py
+++ b/map_machine/util.py
@@ -15,6 +15,8 @@ class MinMax:
 
     def update(self, value: Any) -> None:
         """Update minimum and maximum with new value."""
+        if value is None:
+            return
         self.min_ = value if not self.min_ or value < self.min_ else self.min_
         self.max_ = value if not self.max_ or value > self.max_ else self.max_
 


### PR DESCRIPTION
If a node tag without timestamp is parsed a TypeError is thrown.

```
<node id='-25388' action='modify' visible='true' lat='1.234567' lon='9.876543' />
```

```
Traceback (most recent call last):
  File "…/.local/bin/map-machine", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "…/map-machine/map_machine/main.py", line 44, in main
    mapper.render_map(arguments)
  File "…/map-machine/map_machine/mapper.py", line 367, in render_map
    osm_data.parse_osm_file(input_file_name)
  File "…/map-machine/map_machine/osm/osm_reader.py", line 446, in parse_osm_file
    self.parse_osm(ElementTree.parse(file_name).getroot())
  File "…/map-machine/map_machine/osm/osm_reader.py", line 479, in parse_osm
    self.add_node(node)
  File "…/map-machine/map_machine/osm/osm_reader.py", line 368, in add_node
    self.time.update(node.timestamp)
  File "…/map-machine/map_machine/util.py", line 18, in update
    self.min_ = value if not self.min_ or value < self.min_ else self.min_
                                          ^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'NoneType' and 'datetime.datetime'
```

This pullrequest adds a check for `None`.