### PR TITLE
Add background option to enable/disable background.

### DIFF
--- a/map_machine/map_configuration.py
+++ b/map_machine/map_configuration.py
@@ -63,6 +63,7 @@ class MapConfiguration:
     show_overlapped: bool = False
     credit: Optional[str] = "© OpenStreetMap contributors"
     show_credit: bool = True
+    draw_background: bool = True
 
     @classmethod
     def from_options(
@@ -85,6 +86,7 @@ class MapConfiguration:
             options.building_colors,
             options.show_overlapped,
             show_credit=not options.hide_credit,
+            draw_background=options.background,
         )
 
     def is_wireframe(self) -> bool:

--- a/map_machine/mapper.py
+++ b/map_machine/mapper.py
@@ -57,9 +57,14 @@ class Map:
 
     def draw(self, constructor: Constructor) -> None:
         """Draw map."""
-        self.svg.add(
-            Rect((0.0, 0.0), self.flinger.size, fill=self.background_color)
-        )
+        if self.configuration.draw_background:
+            logging.info("Drawing background...")
+            self.svg.add(
+                Rect((0.0, 0.0), self.flinger.size, fill=self.background_color)
+            )
+        else:
+            logging.info("Drawing no background")
+
         logging.info("Drawing ways...")
 
         figures: list[StyledFigure] = constructor.get_sorted_figures()

--- a/map_machine/ui/cli.py
+++ b/map_machine/ui/cli.py
@@ -214,6 +214,12 @@ def add_map_arguments(parser: argparse.ArgumentParser) -> None:
         action=argparse.BooleanOptionalAction,
         default=False,
     )
+    parser.add_argument(
+        "--background",
+        help="enable or disable the background e.g. to use it as layer",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
 
 
 def add_tile_arguments(parser: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
Since there is no RGBA support in the used colour package https://github.com/vaab/colour/issues/42 I have added an option to not add the background rect. This allows to render osm files, that can then be used as overlay/layer on top of other base map images.

(Was #166 )