### PR TITLE
Fix OSM API gzip response handling

### DIFF
--- a/map_machine/osm/osm_getter.py
+++ b/map_machine/osm/osm_getter.py
@@ -2,7 +2,6 @@
 import logging
 import time
 import gzip
-from io import BytesIO
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -42,12 +41,12 @@ def get_osm(
         {"bbox": boundary_box.get_format()},
     )
 
-    # Try to decompress gzip content if needed
+    # Try to decompress gzip content if needed.
     try:
-        if content.startswith(b"\x1f\x8b"):  # gzip magic header
+        if content.startswith(b"\x1f\x8b"):  # gzip magic header.
             content = gzip.decompress(content)
     except Exception:
-        pass  # If decompression fails, continue with original content
+        pass  # If decompression fails, continue with original content.
 
     if not content.startswith(b"<"):
         if content == (
@@ -78,17 +77,15 @@ def get_data(address: str, parameters: dict[str, str]) -> bytes:
     logging.info(f"Getting {address}...")
     headers = {
         "User-Agent": "map-machine/1.0",
-        "Accept-Encoding": "identity"  # Disable compression to avoid gzip issues
+        # Disable compression to avoid gzip issues.
+        "Accept-Encoding": "identity",
     }
     pool_manager: urllib3.PoolManager = urllib3.PoolManager()
     urllib3.disable_warnings()
 
     try:
         result = pool_manager.request(
-            "GET", 
-            address, 
-            fields=parameters,
-            headers=headers
+            "GET", address, fields=parameters, headers=headers
         )
     except urllib3.exceptions.MaxRetryError:
         raise NetworkError("Cannot download data: too many attempts.")


### PR DESCRIPTION
### Problem Description
The map-machine currently fails with "Cannot download data" error when trying to download data from the OpenStreetMap API in some environments (particularly Docker containers). This happens because the OSM API returns gzip-compressed responses, but the code in `osm_getter.py` expects the response to start with an XML opening bracket `<`.

### Root Cause
When the OSM API returns compressed (gzip) data, the binary content starts with gzip magic bytes `\x1f\x8b` instead of XML's `<`. This causes map-machine to reject the response as invalid and raise a "Cannot download data" error.

### Evidence and Logs
With original code, when downloading a larger area:
```
INFO Getting https://api.openstreetmap.org/api/0.6/map...
CRITICAL Cannot download data.
```

With the fixed code, we get a proper error for large areas:
```
INFO Getting https://api.openstreetmap.org/api/0.6/map...
CRITICAL Cannot download data: too many nodes (limit is 50000). Try to request smaller area.
```

And for appropriately sized areas, it works correctly:
```
INFO Getting https://api.openstreetmap.org/api/0.6/map...
INFO Constructing ways...
INFO Constructing nodes...
INFO Drawing ways...
INFO Drawing main icons...
INFO Drawing extra icons...
INFO Drawing texts...
INFO Writing output SVG to output/paris_small_area_fixed.svg...
```