### PR TITLE
Migrate minimum Python version from 3.9 to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "map-machine"
 description = "Map Machine: Python map renderer for OpenStreetMap with custom icon set."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "Sergey Vartanov", email = "me@enzet.ru" }]
 classifiers = [


### PR DESCRIPTION
## Summary

This pull request updates the minimum required Python version from 3.9 to 3.10 for the Map Machine project.

## Changes Made

- **pyproject.toml**: Updated `requires-python` from `>=3.9` to `>=3.10`

## Motivation

Python 3.9 has reached its end-of-life (EOL) as of October 2025. This migration ensures:
- The project stays on supported Python versions with active security updates
- Users have access to newer Python features and performance improvements introduced in 3.10
- Compatibility with modern development tools and packages

## Testing

- Verified the project configuration is valid
- No breaking changes expected as Python 3.10 is backward compatible with 3.9 code

Fixes #186