### PR TITLE
fix InvalidConfigError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ description = "Map Machine: Python map renderer for OpenStreetMap with custom ic
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Sergey Vartanov", email = "me@enzet.ru" }]
 keywords = [
     "openstreetmap",
@@ -25,7 +26,6 @@ classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Fixes the following deprecation error, which i get when i want to build the docker container. During step `pip install .` the error occurs:

```
53.55 Processing /app
53.56   Installing build dependencies: started
55.16   Installing build dependencies: finished with status 'done'
55.16   Getting requirements to build wheel: started
55.78   Getting requirements to build wheel: finished with status 'error'
55.79   error: subprocess-exited-with-error
55.79
55.79   × Getting requirements to build wheel did not run successfully.
55.79   │ exit code: 1
55.79   ╰─> [29 lines of output]
55.79       Traceback (most recent call last):
55.79         File
"/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py",
line 389, in <module>
55.79           main()
55.79         File
"/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py",
line 373, in main
55.79           json_out["return_val"] = hook(**hook_input["kwargs"])
55.79         File
"/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py",
line 143, in get_requires_for_build_wheel
55.79           return hook(config_settings)
55.79         File
"/tmp/pip-build-env-kba6wfs5/overlay/lib/python3.10/site-packages/setuptools/build_meta.py",
line 333, in get_requires_for_build_wheel
55.79           return self._get_build_requires(config_settings,
requirements=[])
55.79         File
"/tmp/pip-build-env-kba6wfs5/overlay/lib/python3.10/site-packages/setuptools/build_meta.py",
line 301, in _get_build_requires
55.79           self.run_setup()
55.79         File
"/tmp/pip-build-env-kba6wfs5/overlay/lib/python3.10/site-packages/setuptools/build_meta.py",
line 317, in run_setup
55.79           exec(code, locals())
55.79         File "<string>", line 1, in <module>
55.79         File
"/tmp/pip-build-env-kba6wfs5/overlay/lib/python3.10/site-packages/setuptools/__init__.py",
line 117, in setup
55.79           return distutils.core.setup(**attrs)  # type:
ignore[return-value]
55.79         File
"/tmp/pip-build-env-kba6wfs5/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py",
line 160, in setup
55.79           dist.parse_config_files()
55.79         File
"/tmp/pip-build-env-kba6wfs5/overlay/lib/python3.10/site-packages/setuptools/dist.py",
line 762, in parse_config_files
55.79           pyprojecttoml.apply_configuration(self, filename,
ignore_option_errors)
55.79         File
"/tmp/pip-build-env-kba6wfs5/overlay/lib/python3.10/site-packages/setuptools/config/pyprojecttoml.py",
line 73, in apply_configuration
55.79           return _apply(dist, config, filepath)
55.79         File
"/tmp/pip-build-env-kba6wfs5/overlay/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py",
line 61, in apply
55.79           dist._finalize_license_expression()
55.79         File
"/tmp/pip-build-env-kba6wfs5/overlay/lib/python3.10/site-packages/setuptools/dist.py",
line 430, in _finalize_license_expression
  55.79           raise InvalidConfigError(
  55.79       setuptools.errors.InvalidConfigError: License classifiers
  have been superseded by license expressions (see
  https://peps.python.org/pep-0639/). Please remove:
  55.79
  55.79       License :: OSI Approved :: MIT License
  55.79       [end of output]
  55.79
  55.79   note: This error originates from a subprocess, and is likely
  not a problem with pip.
  55.79 ERROR: Failed to build 'file:///app' when getting requirements
  to build wheel

      )
```

This error also occurs when `pip install
git+https://github.com/enzet/map-machine` is called.